### PR TITLE
'Add to Favorites' button makes API call

### DIFF
--- a/public/js/controllers/show.js
+++ b/public/js/controllers/show.js
@@ -50,6 +50,12 @@ app.controller('ShowCtrl', function($rootScope, $scope, $location, $stateParams,
   });
 
   $scope.addToFavorites = function () {
-    console.log('adding this podcast to favorites...');
+    var userId = $rootScope.currentUser.id;
+    var podcastId = $scope.view.podcast.collectionId;
+
+    $http.get('/api/users/' + userId + '/favorite/' + podcastId)
+        .then(function(data){
+          console.log(data);
+        });
   };
 });


### PR DESCRIPTION
Clicking the "Add to Favorites" button the show page makes a call to '/api/users/:user_id/favorite/:podcast_id'.
